### PR TITLE
Fix markup typo

### DIFF
--- a/src/components/Achievements.astro
+++ b/src/components/Achievements.astro
@@ -4,7 +4,7 @@ import MailIcon from "@/assets/MailIcon.astro";
 
 <section class="relative flex flex-col items-center justify-center gap-8 h-[175dvh] overflow-hidden ">
     <div class="absolute w-full h-full">
-        <dir class="white-filter -z-10"></dir>
+        <div class="white-filter -z-10"></div>
         <div class="absolute grid-overlay -z-20"></div>
     </div>
     <MailIcon />


### PR DESCRIPTION
## Summary
- fix <dir> typo in Achievements component

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f0f8efcc83338f952d7d68c34691