### PR TITLE
Fix static build for blog API routes

### DIFF
--- a/src/components/HomeBlog.astro
+++ b/src/components/HomeBlog.astro
@@ -33,7 +33,7 @@ import BlogItem from './BlogItem.astro';
 <script>
   async function loadBlogPosts() {
     try {
-      const response = await fetch('/api/blog/posts');
+      const response = await fetch('/api/blog-posts');
       const posts = await response.json();
       const recentPosts = posts.slice(0, 4);
       

--- a/src/pages/api/blog-posts.ts
+++ b/src/pages/api/blog-posts.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { getBlogPosts } from '../../../lib/notion';
+import { getBlogPosts } from '../../lib/notion';
 
 export const GET: APIRoute = async () => {
   try {

--- a/src/pages/api/blog/index.ts
+++ b/src/pages/api/blog/index.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { getBlogPosts } from '../../lib/notion';
+import { getBlogPosts } from '../../../lib/notion';
 
 export const GET: APIRoute = async ({ url }) => {
   try {


### PR DESCRIPTION
## Summary
- move the blog list endpoint into an index file so the nested API directory no longer conflicts during static builds
- expose the posts collection endpoint at /api/blog-posts and update the client fetch to match the new path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad150a3fc83338dcfcd4417c61c59