### PR TITLE
fix: normalize Notion tables with multiline cells

### DIFF
--- a/src/core/notion/converters/NormalizeNotionMarkdown.ts
+++ b/src/core/notion/converters/NormalizeNotionMarkdown.ts
@@ -144,12 +144,7 @@ function normalizeTableBlock(block: string): string {
       .replace(/^\|/, "")
       .replace(/\|$/, "")
       .split("|")
-      .map((c) =>
-        c
-          .replace(/\s+/g, " ")
-          .replace(/(<br\s*\/?>\s*){2,}/gi, "<br>")
-          .trim()
-      );
+      .map((cell) => normalizeTableCell(cell));
     return `| ${cells.join(" | ")} |`;
   });
 
@@ -176,6 +171,35 @@ function appendContinuationToRow(prevRow: string, continuation: string): string 
   );
 
   return `| ${parts.join(" | ")} |`;
+}
+
+/**
+ * Normaliza el contenido de una celda de tabla, asegurando que los saltos de
+ * línea internos (ya sean `\n` o `<br>`) se conviertan en `<br>` reales y que
+ * no se pierda formato al compactar espacios.
+ */
+function normalizeTableCell(cell: string): string {
+  const normalizedLines = cell
+    .replace(/\r\n?/g, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .split("\n")
+    .map((segment) => segment.replace(/\s+/g, " ").trim());
+
+  const trimmedLines = trimEmptyEdges(normalizedLines);
+
+  if (trimmedLines.length === 0) return "";
+
+  return trimmedLines.join("<br>").replace(/(<br>\s*){2,}/gi, "<br>");
+}
+
+function trimEmptyEdges(lines: string[]): string[] {
+  let start = 0;
+  let end = lines.length;
+
+  while (start < end && lines[start] === "") start++;
+  while (end > start && lines[end - 1] === "") end--;
+
+  return lines.slice(start, end);
 }
 
 /**

--- a/src/core/notion/converters/NotionMarkdownHtml.ts
+++ b/src/core/notion/converters/NotionMarkdownHtml.ts
@@ -12,9 +12,6 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 export async function markdownToHtml(
   markdownInput: string
 ): Promise<string> {
-  
-  console.log(markdownInput);
-
   const result = await remark()
     .use(remarkGfm)
     .use(html, { sanitize: false })

--- a/src/features/blog/repositories/BlogRepository.ts
+++ b/src/features/blog/repositories/BlogRepository.ts
@@ -29,11 +29,8 @@ export class BlogRepository {
       response.results.map(async (page: any) => {
         const markdown = await pageToMarkdown(page.id);
 
-        const cleanedMd =  normalizeNotionMarkdown( [markdown.parent, ...(markdown.children || [])]
-        .join("\n\n")
-        );
+        const cleanedMd = normalizeNotionMarkdown(markdown);
 
-        console.log(cleanedMd);
         const contentString = await markdownToHtml(cleanedMd);
         return mapPageToBlogPost(page, contentString);
       })


### PR DESCRIPTION
## Summary
- normalize Notion markdown tables by converting in-cell line breaks into `<br>` and trimming empty edges
- remove debug logging and rely on the normalizer to flatten notion-to-md responses before rendering

## Testing
- npm run build *(fails: fetch failed when calling Notion during static generation)*

------
https://chatgpt.com/codex/tasks/task_e_68ec1e5c2a588333a57ded470264e3e8